### PR TITLE
Fix lineComment

### DIFF
--- a/pig.configuration.json
+++ b/pig.configuration.json
@@ -1,8 +1,8 @@
 {
     "comments": {
-        // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "//",
-        // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
+        // symbol used for single line comment.
+        "lineComment": "--",
+        // symbols used for start and end a block comment.
         "blockComment": [ "/*", "*/" ]
     },
     // symbols used as brackets


### PR DESCRIPTION
- Use `--` for line comments to match Pig language specification.